### PR TITLE
update sha.js to 2.3.5 - optimization for sha256/512

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "pbkdf2-compat": "2.0.1",
     "public-encrypt": "1.1.2",
     "ripemd160": "0.2.0",
-    "sha.js": "2.3.4"
+    "sha.js": "2.3.5"
   },
   "devDependencies": {
     "tape": "~2.3.2",


### PR DESCRIPTION
after merging @dcousens's improvements to sha.js https://github.com/dominictarr/sha.js/pull/19#issuecomment-69729879