### PR TITLE
Simplify reporting error for unsupported `createCredentials` api

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ require('create-ecdh/inject')(module.exports, exports);
 require('public-encrypt/inject')(module.exports, exports);
 
 // the least I can do is make error messages for the rest of the node.js/crypto api.
-exports.createCredentials = function () {
+exports.createCredentials = function createCredentials() {
   throw new Error([
     'sorry, createCredentials is not implemented yet',
     'we accept pull requests',

--- a/index.js
+++ b/index.js
@@ -2,23 +2,10 @@
 
 exports.randomBytes = exports.rng = exports.pseudoRandomBytes = exports.prng = require('randombytes')
 
-function error () {
-  var m = [].slice.call(arguments).join(' ')
-  throw new Error([
-    m,
-    'we accept pull requests',
-    'http://github.com/dominictarr/crypto-browserify'
-    ].join('\n'))
-}
-
 exports.createHash = exports.Hash = require('create-hash')
 
 exports.createHmac = exports.Hmac = require('create-hmac')
 
-function each(a, f) {
-  for(var i in a)
-    f(a[i], i)
-}
 var hashes = ['sha1', 'sha224', 'sha256', 'sha384', 'sha512', 'md5', 'rmd160'].concat(Object.keys(require('browserify-sign/algos')))
 exports.getHashes = function () {
   return hashes;
@@ -50,10 +37,10 @@ require('create-ecdh/inject')(module.exports, exports);
 require('public-encrypt/inject')(module.exports, exports);
 
 // the least I can do is make error messages for the rest of the node.js/crypto api.
-each([
-  'createCredentials'
-], function (name) {
-  exports[name] = function () {
-    error('sorry,', name, 'is not implemented yet')
-  }
-})
+exports.createCredentials = function () {
+  throw new Error([
+    'sorry, createCredentials is not implemented yet',
+    'we accept pull requests',
+    'http://github.com/dominictarr/crypto-browserify'
+  ].join('\n'));
+};

--- a/index.js
+++ b/index.js
@@ -41,6 +41,6 @@ exports.createCredentials = function createCredentials() {
   throw new Error([
     'sorry, createCredentials is not implemented yet',
     'we accept pull requests',
-    'http://github.com/dominictarr/crypto-browserify'
+    'https://github.com/crypto-browserify/crypto-browserify'
   ].join('\n'));
 };


### PR DESCRIPTION
Using `each` for just one string seems like a lot of un-necessary overhead.  It also seemed a little pointless to use a separate `error` function when we only call it from that one location.