### PR TITLE
Simplify reporting of un-implemented methods and add privateEncrypt/publicDecrypt

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,23 +2,10 @@
 
 exports.randomBytes = exports.rng = exports.pseudoRandomBytes = exports.prng = require('randombytes')
 
-function error () {
-  var m = [].slice.call(arguments).join(' ')
-  throw new Error([
-    m,
-    'we accept pull requests',
-    'http://github.com/dominictarr/crypto-browserify'
-    ].join('\n'))
-}
-
 exports.createHash = exports.Hash = require('create-hash')
 
 exports.createHmac = exports.Hmac = require('create-hmac')
 
-function each(a, f) {
-  for(var i in a)
-    f(a[i], i)
-}
 var hashes = ['sha1', 'sha224', 'sha256', 'sha384', 'sha512', 'md5', 'rmd160'].concat(Object.keys(require('browserify-sign/algos')))
 exports.getHashes = function () {
   return hashes;
@@ -50,10 +37,16 @@ require('create-ecdh/inject')(module.exports, exports);
 require('public-encrypt/inject')(module.exports, exports);
 
 // the least I can do is make error messages for the rest of the node.js/crypto api.
-each([
-  'createCredentials'
-], function (name) {
+[
+  'createCredentials',
+  'privateEncrypt',
+  'publicDecrypt'
+].forEach(function (name) {
   exports[name] = function () {
-    error('sorry,', name, 'is not implemented yet')
+    throw new Error([
+      'sorry, ' + name + ' is not implemented yet',
+      'we accept pull requests',
+      'https://github.com/crypto-browserify/crypto-browserify'
+    ].join('\n'));
   }
 })


### PR DESCRIPTION
This is an alternative to #117 for if we don't manage to get privateEncrypt and publicDecrypt implemented quickly.  It at least drops the `each` helper, given that we already use `.forEach` elsewhere in the file.  It also in-lines the `error` function, as having it separate wasn't really adding anything.