### PR TITLE
Add des

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ var p = require('pbkdf2')
 exports.pbkdf2 = p.pbkdf2
 exports.pbkdf2Sync = p.pbkdf2Sync
 
-var aes = require('browserify-aes')
+var aes = require('browserify-cipher')
 ;[
   'Cipher',
   'createCipher',

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "node": "*"
   },
   "dependencies": {
-    "browserify-aes": "^1.0.0",
+    "browserify-cipher": "^1.0.0",
     "browserify-sign": "^3.0.1",
     "create-ecdh": "^2.0.0",
     "create-hash": "^1.1.0",

--- a/test/aes.js
+++ b/test/aes.js
@@ -1,5 +1,5 @@
 var test = require('tape')
-var crypto = require('browserify-aes/browser')
+var crypto = require('browserify-cipher/browser')
 var randomBytes = require('randombytes')
 
 test('ciphers', function (t) {

--- a/test/create-hash.js
+++ b/test/create-hash.js
@@ -37,6 +37,5 @@ function testLib (name, createHash) {
         t.end()
       })
     })
-
   })
 }

--- a/test/create-hmac.js
+++ b/test/create-hmac.js
@@ -31,7 +31,6 @@ function testLib (name, createHmac) {
         })
         t.end()
       })
-
     })
   })
 }

--- a/test/public-encrypt.js
+++ b/test/public-encrypt.js
@@ -15,7 +15,6 @@ test('publicEncrypt/privateDecrypt', function (t) {
     // note encryption is ranomized so can't test to see if they encrypt the same
     t.equals(crypto1.privateDecrypt(rsa.private, new Buffer(encrypted, 'hex')).toString(), 'hello there I am a nice message', 'decrypt it properly')
     t.equals(crypto2.privateDecrypt(rsa.private, new Buffer(encrypted, 'hex')).toString(), 'hello there I am a nice message', 'decrypt it properly')
-
   })
   t.test('can round trip', function (t) {
     t.plan(2)
@@ -23,7 +22,6 @@ test('publicEncrypt/privateDecrypt', function (t) {
     // note encryption is ranomized so can't test to see if they encrypt the same
     t.equals(crypto1.privateDecrypt(rsa.private, crypto2.publicEncrypt(rsa.public, new Buffer(msg))).toString(), msg, 'round trip it')
     t.equals(crypto2.privateDecrypt(rsa.private, crypto1.publicEncrypt(rsa.public, new Buffer(msg))).toString(), msg, 'round trip it')
-
   })
 })
 
@@ -34,6 +32,5 @@ test('privateEncrypt/publicDecrypt', function (t) {
     // note encryption is ranomized so can't test to see if they encrypt the same
     t.equals(crypto1.publicDecrypt(rsa.public, crypto2.privateEncrypt(rsa.private, new Buffer(msg))).toString(), msg, 'round trip it')
     t.equals(crypto2.publicDecrypt(rsa.public, crypto1.privateEncrypt(rsa.private, new Buffer(msg))).toString(), msg, 'round trip it')
-
   })
 })

--- a/test/random-bytes.js
+++ b/test/random-bytes.js
@@ -19,7 +19,6 @@ for (var randomBytesName in randomBytesFunctions) {
       t.ok(/not supported/.test(err.message), '"not supported"  is in error message')
       t.end()
     }
-
   })
 
   test(randomBytesName, function (t) {
@@ -38,7 +37,7 @@ for (var randomBytesName in randomBytesFunctions) {
     var L = 1000
     var b = randomBytes(L)
 
-    var mean = [].reduce.call(b, function (a, b) { return a + b}, 0) / L
+    var mean = [].reduce.call(b, function (a, b) { return a + b }, 0) / L
 
     // test that the random numbers are plausably random.
     // Math.random() will pass this, but this will catch
@@ -57,6 +56,5 @@ for (var randomBytesName in randomBytesFunctions) {
     t.ok(mean > expected - smean)
 
     t.end()
-
   })
 }


### PR DESCRIPTION
adds a new browserify-cipher package that grabs both browserify-aes and browserify-des and only requires them to provide create[De]cipheriv.   If more ciphers need to be added we can now add them to browserify-cipher (i.e. if somebody wants to add blowfish or openssl adds chacha).

I ended up not removing the createCipher stuff from browseriify-aes mainly because then I'd need to rewrite the tests but since browserify-cipher never uses them at some point in the future we can remove that without a problem here.

Parse-asn1 also relies on browserify-aes but I need to double check if in context it's possible to have des encrypted keys, if so I'll need to update that too.

This adds

- des-ecb
- des
- des-cbc
- des3
- des-ede3-cbc
- des-ede3
- des-ede-cbc
- des-ede