### PR TITLE
bump dependencies for use with bn.js 4.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,14 +19,14 @@
   },
   "dependencies": {
     "browserify-cipher": "^1.0.0",
-    "browserify-sign": "^3.0.1",
-    "create-ecdh": "^2.0.2",
+    "browserify-sign": "^4.0.0",
+    "create-ecdh": "^4.0.0",
     "create-hash": "^1.1.0",
     "create-hmac": "^1.1.0",
-    "diffie-hellman": "^3.0.1",
+    "diffie-hellman": "^5.0.0",
     "inherits": "^2.0.1",
     "pbkdf2": "^3.0.3",
-    "public-encrypt": "^2.0.0",
+    "public-encrypt": "^4.0.0",
     "randombytes": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
new features added due to this bump include:

- 2 more curves, p384 and p521 for use with ECDH and ECDSA, which are supported by the web crypto api and node already 
- diffie-hellman now lazily checks whether the prime is safe to avoid doing unnecessary work 