### PR TITLE
Remove browser from package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,8 +39,5 @@
     "zuul": "^3.6.0"
   },
   "optionalDependencies": {},
-  "browser": {
-    "crypto": false
-  },
   "license": "MIT"
 }


### PR DESCRIPTION
This doesn't make sense for a package that is meant to be a shim for the
browser and also it creates a segfault when using spack and aliasing
`crypto` to `crypto-browserify`.