### PR TITLE
bump browserify-sign to 4.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "browserify-cipher": "^1.0.0",
-    "browserify-sign": "^4.0.0",
+    "browserify-sign": "^4.2.1",
     "create-ecdh": "^4.0.0",
     "create-hash": "^1.1.0",
     "create-hmac": "^1.1.0",


### PR DESCRIPTION
While using crypto-browserify, I receive the following message:
```
> (node:22630) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
```

On using the `--trace-deprecation` flag with Node it seems to be coming from its dependency browserify-sign. The newest version of that package does not use the `Buffer` constructor. This PR bumps browserify-sign to the most up-to-date version (4.2.1).